### PR TITLE
background color and text color change when dark mode is activiated

### DIFF
--- a/src/javascripts/components/darkMode.js
+++ b/src/javascripts/components/darkMode.js
@@ -1,0 +1,13 @@
+const darkModeToggle = () => {
+  $('#dark-mode').on('click', () => {
+    if ($('#dark-mode').is(':checked')) {
+      $('body').css('background-color', 'black');
+      $('body').css('color', 'white');
+    } else {
+      $('body').css('background-color', 'antiquewhite');
+      $('body').css('color', 'brown');
+    }
+  });
+};
+
+export default { darkModeToggle };

--- a/src/javascripts/main.js
+++ b/src/javascripts/main.js
@@ -2,6 +2,7 @@ import navbar from './components/navbar';
 import Printmessages from './components/printMessages';
 import clearMessages from './components/clearButton';
 import font from './components/fontSize';
+import darkMode from './components/darkMode';
 import '../styles/main.scss';
 
 const init = () => {
@@ -9,6 +10,7 @@ const init = () => {
   Printmessages.addmessages();
   $('#clear-btn').click(clearMessages);
   font.fontSizeToggle();
+  darkMode.darkModeToggle();
 };
 
 init();


### PR DESCRIPTION
## Description
When the dark mode checkbox is clicked, the background of the page turns black and the text in the navbar turns white.

## Related Issue
#3 

## Motivation and Context
The user wanted to be able to view the page in dark mode in case their eyes were hurting.

## How Can This Be Tested?
git fetch origin darkMode


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)